### PR TITLE
Fixing the last command for installing bazel from tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,11 @@ This repository contains a collection of Homebrew (aka, Brew) "formulae" for Baz
 ```
 $ brew tap bazelbuild/tap
 $ brew tap-pin bazelbuild/tap
+$ brew install bazel
+```
+
+or alternatively you can refer to formula by its full name
+
+```
 $ brew install bazelbuild/tap/bazel
 ```

--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ This repository contains a collection of Homebrew (aka, Brew) "formulae" for Baz
 ```
 $ brew tap bazelbuild/tap
 $ brew tap-pin bazelbuild/tap
-$ brew install bazel
+$ brew install bazelbuild/tap/bazel
 ```


### PR DESCRIPTION
This seems to be the correct way of installing bazel from tap.