### PR TITLE
Add bazelisk as `bazelisk` as well as `bazel`

### DIFF
--- a/Formula/bazelisk.rb
+++ b/Formula/bazelisk.rb
@@ -28,7 +28,8 @@ class Bazelisk < Formula
   conflicts_with "bazelbuild/tap/bazel", :because => "Bazelisk replaces the bazel binary"
 
   def install
-    bin.install "bazelisk-darwin-amd64" => "bazel"
+    bin.install "bazelisk-darwin-amd64" => "bazelisk"
+    bin.install_symlink "bazelisk" => "bazel"
   end
 
   test do
@@ -37,5 +38,6 @@ class Bazelisk < Formula
     touch testpath/"WORKSPACE"
     (testpath/".bazelversion").write "0.28.1"
     system bin/"bazel", "version"
+    system bin/"bazelisk", "version"
   end
 end


### PR DESCRIPTION
Makes `which bazelisk` point to the `bazelisk` binary as well as `which bazel`.

```bash
/usr/local/bin/bazel -> ../Cellar/bazelisk/1.0/bin/bazelisk
/usr/local/bin/bazelisk -> ../Cellar/bazelisk/1.0/bin/bazelisk
```

Benefits:

1. Whether the user has installed from this tap or the upstream homebrew
   one, you can guarantee that `/usr/local/bin/bazelisk` exists.
2. When debugging you can explicitly run `bazelisk build //...` to make
   sure `bazelisk` is being run (not some other bazel binary that got
   ahead of it on the path for some reason).

Fixes: https://github.com/bazelbuild/homebrew-tap/issues/68