### PR TITLE
Correct bazelisk v1.2.0 checksum

### DIFF
--- a/Formula/bazelisk.rb
+++ b/Formula/bazelisk.rb
@@ -21,7 +21,7 @@ class Bazelisk < Formula
   # To generate run:
   # curl -L -N -s https://github.com/bazelbuild/bazelisk/releases/download/v1.2.0/bazelisk-darwin-amd64 | shasum -a 256
   # on macOS
-  sha256 "6bfca2304cc2258578658d95a6e8dbe43d3ae5dd089076128c726cf14b8c2b8f"
+  sha256 "c9764d559b044a69ec860235d46c5cc7d28e98cb378dd449b7c9fe53f696aa07"
 
   bottle :unneeded
 


### PR DESCRIPTION
Currently `brew install bazelbuild/tap/bazelisk` fails with the following:

```
==> Tapping bazelbuild/tap
Cloning into '/usr/local/Homebrew/Library/Taps/bazelbuild/homebrew-tap'...
remote: Enumerating objects: 11, done.
remote: Counting objects: 100% (11/11), done.
remote: Compressing objects: 100% (11/11), done.
remote: Total 11 (delta 1), reused 3 (delta 0), pack-reused 0
Unpacking objects: 100% (11/11), done.
Tapped 3 formulae (42 files, 51KB).
==> Installing bazelisk from bazelbuild/tap
==> Downloading https://github.com/bazelbuild/bazelisk/releases/download/v1.2.0/bazelisk-darwin-amd64
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/149661467/54792900-234a-11ea-8134-faf6a597f7d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20191220%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20191220T182752Z&X-Am
######################################################################## 100.0%
Error: An exception occurred within a child process:
  ChecksumMismatchError: SHA256 mismatch
Expected: 6bfca2304cc2258578658d95a6e8dbe43d3ae5dd089076128c726cf14b8c2b8f
  Actual: c9764d559b044a69ec860235d46c5cc7d28e98cb378dd449b7c9fe53f696aa07
 Archive: /Users/pivotal/Library/Caches/Homebrew/downloads/49bcf3ae6f2484900431af3c21d7d5f7d324dc128ac8be370cbaae117ffa0b4c--bazelisk-darwin-amd64
To retry an incomplete download, remove the file above.
```

This change corrects the expected checksum, generated via:
```
curl -L -N -s https://github.com/bazelbuild/bazelisk/releases/download/v1.2.0/bazelisk-darwin-amd64 | shasum -a 256
```