### PR TITLE
Install zsh completion with bazelisk

### DIFF
--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -17,7 +17,7 @@ class Bazel < Formula
   homepage "https://bazel.build/"
   url "https://releases.bazel.build/3.1.0/release/bazel-3.1.0-installer-darwin-x86_64.sh", :using => :nounzip
   version "3.1.0"
-  
+
   # To generate run:
   # curl -LNf https://releases.bazel.build/3.1.0/release/bazel-3.1.0-installer-darwin-x86_64.sh | shasum -a 256
   # on macOS

--- a/Formula/bazelisk.rb
+++ b/Formula/bazelisk.rb
@@ -27,9 +27,20 @@ class Bazelisk < Formula
 
   conflicts_with "bazelbuild/tap/bazel", :because => "Bazelisk replaces the bazel binary"
 
+  resource "bazel_zsh_completion" do
+    url "https://raw.githubusercontent.com/bazelbuild/bazel/3.1.0/scripts/zsh_completion/_bazel"
+    # To generate run:
+    # curl -L -N -s https://raw.githubusercontent.com/bazelbuild/bazel/3.1.0/scripts/zsh_completion/_bazel | shasum -a 256
+    # on macOS
+    sha256 "d82384f75ef538c9addf4e313773b2c231b076f58b01dd24ba14f350869ecf3d"
+  end
+
   def install
     bin.install "bazelisk-darwin-amd64" => "bazelisk"
     bin.install_symlink "bazelisk" => "bazel"
+    resource("bazel_zsh_completion").stage {
+      zsh_completion.install "_bazel"
+    }
   end
 
   test do


### PR DESCRIPTION
This isn't ideal, as we should really be dynamically updating the
completion based on the bazel version in the current repo, but that
would take a lot more changes to bazelisk to provide a stable directory
for that.

This at least gives reasonable completions for those who keep to the
latest release.