### PR TITLE
Add github mirror for users in China

### DIFF
--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -16,6 +16,8 @@ class Bazel < Formula
   desc "Fast, scalable, multi-language and extensible build system"
   homepage "https://bazel.build/"
   url "https://releases.bazel.build/3.1.0/release/bazel-3.1.0-installer-darwin-x86_64.sh", :using => :nounzip
+  # Mirror for users in China
+  mirror "https://github.com/bazelbuild/bazel/releases/download/3.1.0/bazel-3.1.0-installer-darwin-x86_64.sh"
   version "3.1.0"
   
   # To generate run:


### PR DESCRIPTION
Users have reported that downloads from https://releases.bazel.build became
inaccessible from China: https://github.com/bazelbuild/bazel/pull/11403

Verified using https://www.websitepulse.com/tools/china-firewall-test that
downloads from github should work (and downloads from releases.bazel.build
don't).